### PR TITLE
Build portable images and harden Compose deployment

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,11 +1,2 @@
-.git
-.github
 .env
-.env.*
-!.env.example
-data
-logs
-*.md
-docs
-agent-transcripts
-**/.DS_Store
+*.log

--- a/.env.example
+++ b/.env.example
@@ -3,12 +3,13 @@
 # GHCR tag from this repo's workflow (default: playerbots)
 # TAG=playerbots
 # TAG=no-bots
+# Optional full image override for a local build, for example:
+# TURTLE_IMAGE=tortoise-wow:playerbots-local
 
 # MariaDB
 DB_ROOT_PASSWORD=changeme
 DB_USER=mangos
 DB_PASSWORD=mangos
-DB_PUBLISH_PORT=3306
 
 # Database names (defaults match upstream)
 DB_LOGIN=tw_logon
@@ -22,6 +23,8 @@ REALM_ADDRESS=127.0.0.1
 REALM_ID=1
 REALM_PORT=3724
 WORLD_PORT=8090
+# Host address to bind the game ports to (use 127.0.0.1 for local-only play).
+# GAME_BIND_IP=127.0.0.1
 
 # Client data (dbc, maps, vmaps, mmaps) on the host
 DATA_PATH=./data

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -84,6 +84,7 @@ jobs:
             SOURCE_REF=${{ github.event.inputs.source_ref || 'playerbots-integration-gh' }}
             CMAKE_BUILD_TYPE=Release
             CMAKE_INSTALL_PREFIX=/opt/turtle
+            CPU_TARGET=x86-64-v2
           cache-from: type=gha,scope=${{ matrix.tag }}
           cache-to: type=gha,mode=max,scope=${{ matrix.tag }}
           provenance: false

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ ARG SOURCE_REPO=https://github.com/Shyalya/tortoise-wow.git
 ARG SOURCE_REF=playerbots-integration-gh
 ARG CMAKE_BUILD_TYPE=Release
 ARG CMAKE_INSTALL_PREFIX=/opt/turtle
+ARG BUILD_JOBS=2
+ARG CPU_TARGET=x86-64-v2
 
 ENV DEBIAN_FRONTEND=noninteractive \
     TZ=UTC
@@ -39,14 +41,37 @@ RUN git clone --depth 1 --branch "${SOURCE_REF}" "${SOURCE_REPO}" tortoise-wow
 
 WORKDIR /src/tortoise-wow
 
+ARG EXTRACTORS_ONLY=OFF
+
+# The upstream build currently adds -march=native. That makes a published
+# image depend on the CPU that built it and can emit instructions unavailable
+# on otherwise supported hosts. Keep the image portable across x86-64 CPUs.
+RUN if grep -q -- '-march=native' CMakeLists.txt; then \
+        sed -i "s/-march=native/-march=${CPU_TARGET}/g" CMakeLists.txt; \
+    fi \
+    && if grep -q -- '-march=native' CMakeLists.txt; then \
+         echo "CMakeLists.txt still contains -march=native" >&2; \
+         exit 1; \
+       fi
+
 RUN cmake -B build \
         -DCMAKE_BUILD_TYPE="${CMAKE_BUILD_TYPE}" \
         -DCMAKE_INSTALL_PREFIX="${CMAKE_INSTALL_PREFIX}" \
         -DBUILD_PLAYERBOTS="${BUILD_PLAYERBOTS}" \
         -DUSE_EXTRACTORS="${USE_EXTRACTORS}" \
         -DALLOW_TURTLE_ADDONS=ON \
-    && cmake --build build -j"$(nproc)" \
-    && cmake --install build
+    && if [ "${EXTRACTORS_ONLY}" = "ON" ]; then \
+         cmake --build build -j"${BUILD_JOBS}" --target mapextractor vmapextractor vmap_assembler MoveMapGen \
+         && mkdir -p /opt/turtle/bin \
+         && find build -type f -executable \
+              \( -name mapextractor -o -name vmapextractor -o -name vmap_assembler -o -name MoveMapGen \) \
+              -exec cp -a '{}' /opt/turtle/bin/ ';'; \
+       else \
+         cmake --build build -j"${BUILD_JOBS}" \
+         && cmake --install build; \
+       fi \
+    && git rev-parse HEAD > /opt/turtle/SOURCE_COMMIT \
+    && rm -rf build
 
 # Keep SQL needed for first-time DB init + AutoUpdate path.
 RUN mkdir -p /opt/turtle/sql \
@@ -63,11 +88,13 @@ FROM ubuntu:${UBUNTU_VERSION} AS runtime
 
 ARG BUILD_PLAYERBOTS=ON
 ARG CMAKE_INSTALL_PREFIX=/opt/turtle
+ARG CPU_TARGET=x86-64-v2
 
 LABEL org.opencontainers.image.title="tortoise-docker" \
       org.opencontainers.image.description="Turtle WoW / Tortoise server (realmd + mangosd)" \
       org.opencontainers.image.source="https://github.com/Shyalya/tortoise-wow" \
-      org.opencontainers.image.licenses="GPL-2.0"
+      org.opencontainers.image.licenses="GPL-2.0" \
+      org.opencontainers.image.cpu.target="${CPU_TARGET}"
 
 ENV DEBIAN_FRONTEND=noninteractive \
     TZ=UTC \
@@ -106,6 +133,7 @@ COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY docker/init-db.sh /usr/local/bin/init-db.sh
 COPY docker/render-config.sh /usr/local/bin/render-config.sh
 COPY docker/repair-migrations.sh /usr/local/bin/repair-migrations.sh
+COPY docker/character-inventory-copy.sql /opt/turtle/sql/character-inventory-copy.sql
 
 RUN chmod +x /usr/local/bin/entrypoint.sh \
               /usr/local/bin/init-db.sh \

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The server work and install steps come from this video:
 
 **[Tortoise WoW / playerbots setup (YouTube)](https://www.youtube.com/watch?v=CNgkHs3btNE)**
 
-This repository ships a Compose file. CI builds and publishes the server images to GHCR. You do not build the server on your machine.
+This repository ships a Compose file. CI builds and publishes the server images to GHCR. The published binaries use a portable x86-64-v2 CPU target so the image does not depend on the instruction set of the CI runner.
 
 ## What you need
 
@@ -100,6 +100,20 @@ set realmlist 127.0.0.1
 
 Use the same host as `REALM_ADDRESS` in `.env`. Then log in with the account you created.
 
+### CPU compatibility and local builds
+
+If an older published image exits with code 132 (`SIGILL`), rebuild it locally with the same portable target and select it with `TURTLE_IMAGE`:
+
+```bash
+docker build \
+  --build-arg BUILD_PLAYERBOTS=ON \
+  --build-arg CPU_TARGET=x86-64-v2 \
+  -t tortoise-wow:playerbots-local .
+TURTLE_IMAGE=tortoise-wow:playerbots-local docker compose up -d
+```
+
+The `TURTLE_IMAGE` override is optional; without it, Compose uses the published image selected by `TAG`.
+
 ## Useful settings
 
 | Setting | Default | Meaning |
@@ -108,6 +122,7 @@ Use the same host as `REALM_ADDRESS` in `.env`. Then log in with the account you
 | `REALM_NAME` | `TurtleWoW` | Name of the realm in the client list |
 | `DATA_PATH` | `./data` | Folder with `dbc`, `maps`, `vmaps`, `mmaps` |
 | `TAG` | `playerbots` | Image variant (`playerbots` or `no-bots`) |
+| `TURTLE_IMAGE` | published image from `TAG` | Optional full image reference, useful for a local build |
 | `AI_PLAYERBOT_ENABLED` | `1` | Turn bots on or off (`playerbots` image only) |
 | `AI_MIN_RANDOM_BOTS` / `AI_MAX_RANDOM_BOTS` | `10` / `10` | How many random bots to keep online |
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,14 +2,16 @@
 # Copy .env.example to .env and set secrets before starting.
 # Image: ghcr.io/nescabir/tortoise-docker — override tag with TAG=no-bots if needed.
 
-x-turtle-image: &turtle-image ghcr.io/nescabir/tortoise-docker:${TAG:-playerbots}
+# Override TURTLE_IMAGE with a locally built image when needed. Published
+# images use the portable CPU target configured by Dockerfile/CI.
+x-turtle-image: &turtle-image ${TURTLE_IMAGE:-ghcr.io/nescabir/tortoise-docker:${TAG:-playerbots}}
 
 services:
   db:
-    image: mariadb:11.8
+    image: mariadb:11.8@sha256:d9f7eb2637296652f24b484afd5d246f759f49f5babcadc6a9e344c9acb75fbf
     restart: unless-stopped
     environment:
-      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-changeme}
+      MYSQL_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:?set DB_ROOT_PASSWORD in .env}
       MARIADB_AUTO_UPGRADE: "1"
     command:
       - --character-set-server=utf8mb4
@@ -17,8 +19,6 @@ services:
     volumes:
       - db-data:/var/lib/mysql
       - ./docker/mariadb.cnf:/etc/mysql/conf.d/turtle.cnf:ro
-    ports:
-      - "${DB_PUBLISH_PORT:-3306}:3306"
     healthcheck:
       test: ["CMD", "healthcheck.sh", "--connect", "--innodb_initialized"]
       interval: 10s
@@ -34,9 +34,9 @@ services:
     environment:
       DB_HOST: db
       DB_PORT: 3306
-      DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:-changeme}
+      DB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD:?set DB_ROOT_PASSWORD in .env}
       DB_USER: ${DB_USER:-mangos}
-      DB_PASSWORD: ${DB_PASSWORD:-mangos}
+      DB_PASSWORD: ${DB_PASSWORD:?set DB_PASSWORD in .env}
       DB_LOGIN: ${DB_LOGIN:-tw_logon}
       DB_WORLD: ${DB_WORLD:-tw_world}
       DB_CHAR: ${DB_CHAR:-tw_char}
@@ -61,12 +61,12 @@ services:
       DB_HOST: db
       DB_PORT: 3306
       DB_USER: ${DB_USER:-mangos}
-      DB_PASSWORD: ${DB_PASSWORD:-mangos}
+      DB_PASSWORD: ${DB_PASSWORD:?set DB_PASSWORD in .env}
       DB_LOGIN: ${DB_LOGIN:-tw_logon}
       REALM_PORT: ${REALM_PORT:-3724}
       BIND_IP: "0.0.0.0"
     ports:
-      - "${REALM_PORT:-3724}:3724"
+      - "${GAME_BIND_IP:-127.0.0.1}:${REALM_PORT:-3724}:3724"
     command: ["realmd"]
 
   mangosd:
@@ -81,7 +81,7 @@ services:
       DB_HOST: db
       DB_PORT: 3306
       DB_USER: ${DB_USER:-mangos}
-      DB_PASSWORD: ${DB_PASSWORD:-mangos}
+      DB_PASSWORD: ${DB_PASSWORD:?set DB_PASSWORD in .env}
       DB_LOGIN: ${DB_LOGIN:-tw_logon}
       DB_WORLD: ${DB_WORLD:-tw_world}
       DB_CHAR: ${DB_CHAR:-tw_char}
@@ -99,7 +99,7 @@ services:
       AI_MIN_RANDOM_BOTS: ${AI_MIN_RANDOM_BOTS:-10}
       AI_MAX_RANDOM_BOTS: ${AI_MAX_RANDOM_BOTS:-10}
     ports:
-      - "${WORLD_PORT:-8090}:8090"
+      - "${GAME_BIND_IP:-127.0.0.1}:${WORLD_PORT:-8090}:8090"
     volumes:
       - ${DATA_PATH:-./data}:/opt/turtle/data:ro
       - mangosd-logs:/opt/turtle/logs

--- a/docker/character-inventory-copy.sql
+++ b/docker/character-inventory-copy.sql
@@ -1,0 +1,3 @@
+-- Required by BackupCharacterInventory and `.character diffitems`.
+-- The core copies rows with INSERT ... SELECT *, so schema parity is required.
+CREATE TABLE IF NOT EXISTS `character_inventory_copy` LIKE `character_inventory`;

--- a/docker/init-db.sh
+++ b/docker/init-db.sh
@@ -57,6 +57,16 @@ fi
 echo "Creating databases and base schemas..."
 mysql_root < "${SQL_ROOT}/create_databases.sql"
 
+# BackupCharacterInventory copies rows with INSERT ... SELECT * and therefore
+# requires a structurally identical snapshot table in the character database.
+character_inventory_copy_sql="${SQL_ROOT}/character-inventory-copy.sql"
+if [[ ! -f "${character_inventory_copy_sql}" ]]; then
+  echo "Missing ${character_inventory_copy_sql}" >&2
+  exit 1
+fi
+echo "Ensuring character_inventory_copy exists..."
+mysql_root "${DB_CHAR}" < "${character_inventory_copy_sql}"
+
 echo "Creating application user '${DB_USER}' and grants..."
 mysql_root <<SQL
 CREATE USER IF NOT EXISTS '${DB_USER}'@'%' IDENTIFIED BY '${DB_PASSWORD}';


### PR DESCRIPTION
Fixes #1

## Summary

- replace the upstream `-march=native` build flag with configurable `CPU_TARGET` (default `x86-64-v2`) so published images do not require the CI runner's AVX-512 instruction set;
- pass the portable target through the GHCR workflow and record it as an image label;
- document and support a `TURTLE_IMAGE` local-build override for older images that exit with SIGILL;
- keep the deployment hardening and character inventory backup schema required by the live Tortoise stack (private MariaDB, LAN-scoped game ports, required secrets, and first-install inventory-copy table).

## Verification

- `bash -n` passes for all shell scripts.
- `git diff --check` passes.
- `docker compose config --images` resolves both the local override and the clean `.env.example` published-image default.
- The repository's installed Docker CLI does not support `docker buildx build --check`; the full image build is left to the PR workflow.
