### PR TITLE
fix(build): bust GHA cache when upstream source moves

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -43,6 +43,18 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Resolve upstream source commit
+        id: source
+        run: |
+          REF="${{ github.event.inputs.source_ref || 'playerbots-integration-gh' }}"
+          SHA="$(git ls-remote https://github.com/Shyalya/tortoise-wow.git "refs/heads/${REF}" | cut -f1)"
+          if [ -z "${SHA}" ]; then
+            echo "Could not resolve ref ${REF} on Shyalya/tortoise-wow" >&2
+            exit 1
+          fi
+          echo "Resolved ${REF} -> ${SHA}"
+          echo "sha=${SHA}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
@@ -76,6 +88,7 @@ jobs:
             USE_EXTRACTORS=OFF
             SOURCE_REPO=https://github.com/Shyalya/tortoise-wow.git
             SOURCE_REF=${{ github.event.inputs.source_ref || 'playerbots-integration-gh' }}
+            SOURCE_COMMIT=${{ steps.source.outputs.sha }}
             CMAKE_BUILD_TYPE=Release
             CMAKE_INSTALL_PREFIX=/opt/turtle
             CPU_TARGET=x86-64-v2

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,10 @@ ARG CMAKE_BUILD_TYPE=Release
 ARG CMAKE_INSTALL_PREFIX=/opt/turtle
 ARG BUILD_JOBS=2
 ARG CPU_TARGET=x86-64-v2
+# Resolved upstream commit SHA, passed in by CI. Declaring it right before the
+# clone RUN busts the layer cache whenever upstream actually moves, without
+# forcing a full rebuild when nothing changed (see issue #6).
+ARG SOURCE_COMMIT=""
 
 ENV DEBIAN_FRONTEND=noninteractive \
     TZ=UTC
@@ -37,7 +41,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 
 WORKDIR /src
 
-RUN git clone --depth 1 --branch "${SOURCE_REF}" "${SOURCE_REPO}" tortoise-wow
+RUN echo "Cloning ${SOURCE_REPO}#${SOURCE_REF} @ ${SOURCE_COMMIT:-unresolved}" \
+    && git clone --depth 1 --branch "${SOURCE_REF}" "${SOURCE_REPO}" tortoise-wow
 
 WORKDIR /src/tortoise-wow
 


### PR DESCRIPTION
The scheduled daily publish workflow relies on docker/build-push-action
with type=gha caching. Since the Dockerfile and build-args never
change, the RUN git clone layer stayed cached indefinitely, so
published images never picked up new commits from Shyalya/tortoise-wow
even though the workflow ran every day.

Resolve the upstream branch's HEAD commit in the workflow and pass it
as a SOURCE_COMMIT build-arg declared right before the clone RUN. The
layer only invalidates when upstream actually has new commits.

Fixes #6

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>