### PR TITLE
docs: clarify GAME_BIND_IP is required for LAN play

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Edit `.env`:
 2. Set `REALM_ADDRESS` to an address your game client can reach.
 3. Set `DATA_PATH` if your client data is not in `./data`.
 
-Use `127.0.0.1` for `REALM_ADDRESS` only when the client runs on the same machine. For another PC on your LAN, use your host LAN IP.
+Use `127.0.0.1` for `REALM_ADDRESS` only when the client runs on the same machine. For another PC on your LAN, use your host LAN IP **and** set `GAME_BIND_IP=0.0.0.0` in `.env` — by default the game ports are only published on `127.0.0.1`, so other machines cannot reach them even if `REALM_ADDRESS` points at your LAN IP.
 
 ### 3. Add client data
 
@@ -175,6 +175,7 @@ Volume names can include your Compose project name. Use `docker volume ls` to co
 | Empty world / no NPCs | First database import failed; check `docker compose logs db-init` |
 | No bots | Use `TAG=playerbots` and `AI_PLAYERBOT_ENABLED=1` |
 | Client crash: interface corrupt | Use the published image from this project; do not strip Turtle addons |
+| LAN client can't reach the realm | Set `GAME_BIND_IP=0.0.0.0` in `.env` (default `127.0.0.1` only accepts connections from the host itself), then `docker compose up -d` |
 
 ## Credits
 


### PR DESCRIPTION
REALM_ADDRESS controls what address the client stores in the
realmlist, but docker-compose.yml still publishes the realmd/mangosd
ports on 127.0.0.1 by default. A user who only sets REALM_ADDRESS to
their LAN IP gets a realm that resolves but never accepts the
connection, because the port itself isn't reachable from the LAN.

Document that GAME_BIND_IP=0.0.0.0 is also required for LAN/remote
play, and add the symptom to the troubleshooting table.

Fixes #5

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>