### PR TITLE
feat: expose server config files for host-side editing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,6 +29,10 @@ WORLD_PORT=8090
 # Client data (dbc, maps, vmaps, mmaps) on the host
 DATA_PATH=./data
 
+# Server config files (mangosd.conf, realmd.conf, ...) on the host, editable
+# between restarts. Settings not managed by an env var above are preserved.
+CONFIG_PATH=./config
+
 # mangosd tuning
 LOG_SQL=0
 DATABASE_AUTOUPDATE_ENABLED=1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .env
 data/
+config/
 logs/
 *.log
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -132,6 +132,18 @@ Keep bot counts low for the first start. Raise them later in `.env`, then run:
 docker compose up -d mangosd
 ```
 
+## Editing server configs
+
+`mangosd.conf`, `realmd.conf`, `aiplayerbot.conf`, and `ahbot.conf` are written to `./config` on the host (or `CONFIG_PATH` from `.env`) the first time the stack starts.
+
+Edit any setting there directly — for example server rates, difficulty, or announce messages. Settings that also have a `.env` variable (see the table above) get overwritten from that variable on every start; everything else you edit is left as-is.
+
+After editing, restart the affected service:
+
+```bash
+docker compose up -d mangosd realmd
+```
+
 ## Common commands
 
 View logs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -67,6 +67,8 @@ services:
       BIND_IP: "0.0.0.0"
     ports:
       - "${GAME_BIND_IP:-127.0.0.1}:${REALM_PORT:-3724}:3724"
+    volumes:
+      - ${CONFIG_PATH:-./config}:/opt/turtle/etc
     command: ["realmd"]
 
   mangosd:
@@ -102,6 +104,7 @@ services:
       - "${GAME_BIND_IP:-127.0.0.1}:${WORLD_PORT:-8090}:8090"
     volumes:
       - ${DATA_PATH:-./data}:/opt/turtle/data:ro
+      - ${CONFIG_PATH:-./config}:/opt/turtle/etc
       - mangosd-logs:/opt/turtle/logs
     command: ["mangosd"]
     # First start builds bot caches / travel data and can take a long time.


### PR DESCRIPTION
render-config.sh only rewrites the handful of keys it manages via sed
and leaves the rest of mangosd.conf/realmd.conf untouched, so a config
directory can safely persist between restarts.

Mount a CONFIG_PATH volume (default ./config) at /opt/turtle/etc for
both realmd and mangosd, so mangosd.conf, realmd.conf,
aiplayerbot.conf, and ahbot.conf can be edited on the host and survive
container restarts/recreation.

Fixes #3

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>