### PR TITLE
fix: use chown during copy and chown specific dirs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -133,12 +133,12 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     && groupadd --gid 1000 turtle \
     && useradd --uid 1000 --gid turtle --home-dir /opt/turtle --shell /usr/sbin/nologin turtle
 
-COPY --from=builder /opt/turtle /opt/turtle
+COPY --chown=1000:1000 --from=builder /opt/turtle /opt/turtle
 COPY docker/entrypoint.sh /usr/local/bin/entrypoint.sh
 COPY docker/init-db.sh /usr/local/bin/init-db.sh
 COPY docker/render-config.sh /usr/local/bin/render-config.sh
 COPY docker/repair-migrations.sh /usr/local/bin/repair-migrations.sh
-COPY docker/character-inventory-copy.sql /opt/turtle/sql/character-inventory-copy.sql
+COPY --chown=1000:1000 docker/character-inventory-copy.sql /opt/turtle/sql/character-inventory-copy.sql
 
 RUN chmod +x /usr/local/bin/entrypoint.sh \
               /usr/local/bin/init-db.sh \
@@ -147,7 +147,7 @@ RUN chmod +x /usr/local/bin/entrypoint.sh \
     && mkdir -p /opt/turtle/data /opt/turtle/logs /opt/turtle/run /var/lib/turtle-init \
     && mkdir -p /opt/turtle/etc.dist \
     && cp /opt/turtle/etc/*.conf.dist /opt/turtle/etc.dist/ \
-    && chown -R turtle:turtle /opt/turtle /var/lib/turtle-init
+    && chown -R turtle:turtle /opt/turtle/data /opt/turtle/etc.dist /opt/turtle/run /opt/turtle/logs /var/lib/turtle-init
 
 WORKDIR /opt/turtle/bin
 


### PR DESCRIPTION
Using `chown -R turtle:turtle /opt/turtle` increases the image size by almost twice the expected amount as the binaries are stored twice in different layers. Once when its copied from the builder and once the owner is changed. This commit fixes this issue.